### PR TITLE
Make onChange work on Safari 

### DIFF
--- a/jquery.json-tag-editor.js
+++ b/jquery.json-tag-editor.js
@@ -194,7 +194,7 @@
                         tag.value = $(this).find('input').val();
                     }
                     else {
-                        Object.assign(tag, $(e).get(0).dataset)
+                        Object.assign(tag, $(e).get(0).dataset, {value: $(e).get(0).dataset.value})
                     }
 
                     if (tag.value) {


### PR DESCRIPTION
... by explicitly adding the value property to the assign clause.

    I saw that the properties of $(e).get(0).dataset are enumerable in Chrome, but not in Safari. This makes the tags object be empty every time, because - as MDN explains - Object.assign only copies own and enumerable properties.

I think they're different because they refer to the objects from the DOM API which will be different for the two browsers.

I don't know whether any other properties that are non-enumerable are missing and causing other problems on Safari.